### PR TITLE
Add range value buttons to RangeSelector - Overview demo

### DIFF
--- a/demo/BlazorDemo.ServerSide/BlazorDemo/Pages/RangeSelector/Overview/RangeSelector-Overview.razor
+++ b/demo/BlazorDemo.ServerSide/BlazorDemo/Pages/RangeSelector/Overview/RangeSelector-Overview.razor
@@ -18,7 +18,9 @@
 
         <DxRangeSelector Width="100%"
                          Data="@Data"
-                         ValueChanged="@OnValueChanged"
+                         SelectedRangeStartValue="RangeSelectorStartValue"
+                         SelectedRangeEndValue="RangeSelectorEndValue"
+                         ValueChanged="OnValueChanged"
                          ValueChangeMode="RangeSelectorValueChangeMode.OnHandleMove">
             <DxRangeSelectorChart>
                 @CreateChartAreaSeries(s => s.Y1)
@@ -27,16 +29,54 @@
             </DxRangeSelectorChart>
             <DxRangeSelectorScale TickInterval="50" />
         </DxRangeSelector>
+
+        <div class="range-btns">
+            <div style="margin-right: 1rem;">
+                <label for="minSpinEdit" class="demo-text cw-320 mb-1">
+                    Min Value:
+                </label>
+                <DxSpinEdit Value="StartValue" ValueChanged="@((double newValue) => OnSpinEditStartValueChanged(newValue))" InputId="minSpinEdit" CssClass="cw-320" Increment="10" MinValue="10" MaxValue="650" />
+            </div>
+
+            <div>
+                <label for="maxSpinEdit" class="demo-text cw-320 mb-1">
+                    Max Value:
+                </label>
+                <DxSpinEdit Value="EndValue" ValueChanged="@((double newValue) => OnSpinEditEndValueChanged(newValue))" InputId="maxSpinEdit" CssClass="cw-320" Increment="10" MinValue="10" MaxValue="650" />
+            </div>
+        </div>
     </DemoChildContent>
 
     @code {
-        object StartValue;
-        object EndValue;
+        double StartValue = 10;
+        double EndValue = 650;
+        double RangeSelectorStartValue = 10;
+        double RangeSelectorEndValue = 650;
         List<ZoomingData> Data;
 
+        void OnSpinEditStartValueChanged(double newStartValue) {
+            if (newStartValue > EndValue) {
+                StartValue = EndValue;
+                return;
+            }
+
+            StartValue = newStartValue;
+            RangeSelectorStartValue = StartValue;
+        }
+
+        void OnSpinEditEndValueChanged(double newEndValue) {
+            if (newEndValue < StartValue) {
+                EndValue = StartValue;
+                return;
+            }
+
+            EndValue = newEndValue;
+            RangeSelectorEndValue = EndValue;
+        }
+
         void OnValueChanged(RangeSelectorValueChangedEventArgs info) {
-            StartValue = info.CurrentRange[0];
-            EndValue = info.CurrentRange[1];
+            StartValue = (double)info.CurrentRange[0];
+            EndValue = (double)info.CurrentRange[1];
         }
 
         protected override void OnInitialized() {

--- a/demo/BlazorDemo.ServerSide/BlazorDemo/Pages/RangeSelector/Overview/RangeSelector-Overview.razor.css
+++ b/demo/BlazorDemo.ServerSide/BlazorDemo/Pages/RangeSelector/Overview/RangeSelector-Overview.razor.css
@@ -1,0 +1,4 @@
+﻿.range-btns {
+    margin-top: 1rem;
+    display: flex;
+}


### PR DESCRIPTION
Card: https://github.com/DevExpress/asptribe/issues/788
Teams discussion: https://teams.microsoft.com/l/message/19:9c6731721afa4447b78718f9e946c2a6@thread.skype/1773836657483?tenantId=e4d60396-9352-4ae8-b84c-e69244584fa4&groupId=a7f26f88-ba0d-4d92-b58b-d5e29b6ba2d0&parentMessageId=1773836657483&teamName=ASP.NET&channelName=Examples&createdTime=1773836657483

Regarding the code, I had to use separate variables for the RangeSelector's **SelectedRangeStartValue** and **SelectedRangeEndValue** properties. If I use the same `StartValue` and `EndValue` variables, dragging the selector range causes an endless loop, which seems like a race condition. Also using two-way binding for those properties (without handling **ValueChanged** event) causes such issues. 